### PR TITLE
Handle filenames with spaces, and add trailing slash to path

### DIFF
--- a/sketch-replace-images.sketchplugin
+++ b/sketch-replace-images.sketchplugin
@@ -8,6 +8,9 @@ var page = [doc currentPage];// the current page (MSPage)
 var layers = [page children]; // A flattened array (NSArray) of all layers in `page`
 
 var relativePath = [doc askForUserInput:"Specify images path relative to document:" initialValue:"./"]
+if (!/\/$/.test(relativePath)) {
+  relativePath = relativePath + "/";
+}
 
 var home_folder = "/Users/" + NSUserName();
 var doc_folder = doc.fileURL().toString().stringByDeletingLastPathComponent();

--- a/sketch-replace-images.sketchplugin
+++ b/sketch-replace-images.sketchplugin
@@ -28,7 +28,12 @@ function replaceImages()
       {
         var imageName = layer.name() + "." + imageTypes[j];
         var url = [NSURL URLWithString:relativePath relativeToURL:doc.fileURL()];
-        url = [NSURL URLWithString:imageName relativeToURL:url];
+
+        // Do URL escaping on imageName
+        var imageNameForUrl = [NSString stringWithFormat:"%@", imageName];
+        imageNameForUrl = [imageNameForUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+
+        url = [NSURL URLWithString:imageNameForUrl relativeToURL:url];
 
         var fileManager = [NSFileManager defaultManager];
         if([fileManager fileExistsAtPath:url.path()])


### PR DESCRIPTION
Hi. This plugin is really useful, but I ran into a few problems using it. So here are some fixes.
1. Files with spaces in the names were failing. This is because `URLWithString:` expects spaces (and other special characters) to be URL encoded. The call to `stringByAddingPercentEscapesUsingEncoding:` addresses this.
2. When typing in the path to the images, you had to include the trailing slash. With this change, the trailing slash is automatically added.

Thanks again for making this plugin. It's a big time-saver for me.
